### PR TITLE
Fix for CPUs without AVX2 support

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -86,8 +86,8 @@ ram.runtime = "50M"
     [resources.sources]
 
       [resources.sources.x64_bookworm]
-      url = "https://github.com/orhtej2/numpy-binary/releases/download/v2.4.6/numpy-2.4.6.tar.gz"
-      sha256 = "11111bed641e372524dfc0718cf2ef3b138ee780b991d147580d831acb7a9f4c"
+      url = "https://github.com/orhtej2/numpy-binary/releases/download/v2.4.6/numpy-v2.4.6-ubuntu-22.04-py3.11.tar.gz"
+      sha256 = "fc4392b376cf998a8ad4570108d17e3ecb5519f6b48493e30b0a02fb5e8ecb7a"
       prefetch = false
       in_subdir = false
       autoupdate.strategy = "latest_github_release"
@@ -95,8 +95,8 @@ ram.runtime = "50M"
       autoupdate.asset = "numpy-\\d+\\.\\d+\\.\\d+-python3.11\\.tar\\.gz$"
 
       [resources.sources.x64_trixie]
-      url = "https://github.com/orhtej2/numpy-binary/releases/download/v2.4.6/numpy-2.4.6-python3.13.tar.gz"
-      sha256 = "11111bed641e372524dfc0718cf2ef3b138ee780b991d147580d831acb7a9f4c"
+      url = "https://github.com/orhtej2/numpy-binary/releases/download/v2.4.6/numpy-v2.4.6-ubuntu-24.04-py3.13.tar.gz"
+      sha256 = "8fb02d3ab777867008f60dd1ee9e2027f18098bd9e18e6942cf614f33999f74c"
       prefetch = false
       in_subdir = false
       autoupdate.strategy = "latest_github_release"

--- a/manifest.toml
+++ b/manifest.toml
@@ -83,6 +83,26 @@ ram.runtime = "50M"
     optional = true
 
   [resources]
+    [resources.sources]
+
+      [resources.sources.x64_bookworm]
+      url = "https://github.com/orhtej2/numpy-binary/releases/download/v2.4.6/numpy-2.4.6.tar.gz"
+      sha256 = "11111bed641e372524dfc0718cf2ef3b138ee780b991d147580d831acb7a9f4c"
+      prefetch = false
+      in_subdir = false
+      autoupdate.strategy = "latest_github_release"
+      autoupdate.upstream = "https://github.com/orhtej2/numpy-binary"
+      autoupdate.asset = "numpy-\\d+\\.\\d+\\.\\d+-python3.11\\.tar\\.gz$"
+
+      [resources.sources.x64_trixie]
+      url = "https://github.com/orhtej2/numpy-binary/releases/download/v2.4.6/numpy-2.4.6-python3.13.tar.gz"
+      sha256 = "11111bed641e372524dfc0718cf2ef3b138ee780b991d147580d831acb7a9f4c"
+      prefetch = false
+      in_subdir = false
+      autoupdate.strategy = "latest_github_release"
+      autoupdate.upstream = "https://github.com/orhtej2/numpy-binary"
+      autoupdate.asset = "numpy-\\d+\\.\\d+\\.\\d+-python3.13\\.tar\\.gz$"
+
     [resources.system_user]
     allow_email = true
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#=================================================
+# PERSONAL HELPERS
+#=================================================
+
+fixupx64numpy() {
+     if ! grep -qE '^flags.* (sse4|LSE)' /proc/cpuinfo; then
+       ynh_setup_source --dest_dir="$install_dir/venv/lib/python3.11/site-packages" --source_id="x64_bookworm"
+     fi
+}

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,6 +6,6 @@
 
 fixupx64numpy() {
      if ! grep -qE '^flags.* (sse4|LSE)' /proc/cpuinfo; then
-       ynh_setup_source --dest_dir="$install_dir/venv/lib/python3.11/site-packages" --source_id="x64_bookworm"
+       ynh_setup_source --dest_dir="$install_dir/venv" --source_id="x64_bookworm"
      fi
 }

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -5,6 +5,7 @@
 #=================================================
 
 source /usr/share/yunohost/helpers
+source _common.sh
 
 #=================================================
 # LOAD SETTINGS
@@ -88,6 +89,8 @@ fi
     ynh_exec_as_app python3 -m venv "$install_dir/venv"
     ynh_hide_warnings ynh_exec_as_app "$install_dir/venv/bin/pip" install --upgrade pip wheel toml pyyaml
     ynh_hide_warnings ynh_exec_as_app "$install_dir/venv/bin/pip" install fittrackee=="$(ynh_app_upstream_version)"
+
+    fixupx64numpy
 
     ynh_safe_rm "$install_dir/.cache/pip"
 popd


### PR DESCRIPTION
## Problem

- NumPy requires support for SSE3+ instructions set, not found on old x64 CPUs

## Solution

- Drop in replacement NumPy artifacts built with baseline x64_v1 baseline

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
